### PR TITLE
add latexmk build script to build references

### DIFF
--- a/latexmkrc.linux
+++ b/latexmkrc.linux
@@ -1,0 +1,5 @@
+$latex="latex -interaction errorstopmode %O %S";
+$bibtex="bibtex -min-crossrefs=20 %O %S";
+$out_dir = 'out';
+$pdf_mode=1;
+@default_files = ('paper.ltx');

--- a/latexmkrc.osx
+++ b/latexmkrc.osx
@@ -1,0 +1,5 @@
+$latex="pdflatex -interaction errorstopmode %O %S";
+$bibtex="bibtex -min-crossrefs=20 %O %S";
+$out_dir = 'out';
+$pdf_mode=1;
+@default_files = ('paper.tex');


### PR DESCRIPTION
run with `latexmk -r latexmk.[linux|osx]`

the pdf and intermediate files are written to the `out` directory which avoids cluttering up the source dir